### PR TITLE
Read environment variables from process rather than user scope

### DIFF
--- a/NBi.Core/Scalar/Resolver/EnvironmentScalarResolver.cs
+++ b/NBi.Core/Scalar/Resolver/EnvironmentScalarResolver.cs
@@ -18,7 +18,7 @@ namespace NBi.Core.Scalar.Resolver
 
         public T Execute()
         {
-            var value = Environment.GetEnvironmentVariable(args.Name, EnvironmentVariableTarget.User);
+            var value = Environment.GetEnvironmentVariable(args.Name);
             return (T)Convert.ChangeType(value, typeof(T));
         }
 


### PR DESCRIPTION
Adjust to expected behavior and easier use in build systems.

Documentation of the different scopes of environment variables is at https://learn.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable?view=net-7.0#system-environment-getenvironmentvariable(system-string) .

This solves #717